### PR TITLE
회원 정보 수정 시, 프로필 이미지가 빈 파일인지 확인하는 기능 구현

### DIFF
--- a/src/main/java/com/dnd/dotchi/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/dotchi/domain/member/service/MemberService.java
@@ -2,6 +2,8 @@ package com.dnd.dotchi.domain.member.service;
 
 import java.util.List;
 
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +29,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @Service
 public class MemberService {
+
+    private static final String EMPTY_FILE_START_NAME = "34f2743d-a9";
 
     private final MemberRepository memberRepository;
     private final CardRepository cardRepository;
@@ -59,8 +63,9 @@ public class MemberService {
 
     @Transactional
     public MemberModifyResponse patchMemberInfo(final Member member, final MemberModifyRequest request) {
-        if(request.memberImage().isPresent()) {
-            final MultipartFile image = request.memberImage().get();
+        final Optional<MultipartFile> multipartFile = request.memberImage();
+        if(isModifyProfileImage(multipartFile)) {
+            final MultipartFile image = multipartFile.get();
             final String fileFullPath = s3FileUploader.upload(image);
             member.setImageUrl(fileFullPath);
         }
@@ -68,6 +73,11 @@ public class MemberService {
         member.setDescription(request.memberDescription());
 
         return MemberModifyResponse.of(MemberRequestResultType.PATCH_MEMBER_INFO_SUCCESS);
+    }
+
+    private boolean isModifyProfileImage(final Optional<MultipartFile> multipartFile) {
+        return multipartFile.isPresent()
+                && !Objects.requireNonNull(multipartFile.get().getOriginalFilename()).startsWith(EMPTY_FILE_START_NAME);
     }
 
 }

--- a/src/test/java/com/dnd/dotchi/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/dnd/dotchi/domain/member/service/MemberServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.given;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.dnd.dotchi.domain.member.dto.request.MemberAuthorizationRequest;
-import com.dnd.dotchi.domain.member.dto.request.MemberInfoRequest;
 import com.dnd.dotchi.domain.member.dto.request.MemberModifyRequest;
 import com.dnd.dotchi.domain.member.dto.response.MemberAuthorizationResponse;
 import com.dnd.dotchi.domain.member.dto.response.MemberAuthorizationResultResponse;
@@ -28,7 +27,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -142,9 +140,9 @@ class MemberServiceTest {
         // data.sql
         final Member member = memberService.findById(1L);
         final MockMultipartFile image
-            = new MockMultipartFile("img", "img", "image/png", "img".getBytes());
+                = new MockMultipartFile("img", "img", "image/png", "img".getBytes());
         final MemberModifyRequest request
-            = new MemberModifyRequest(Optional.of(image),"오뜨","멍청이");
+                = new MemberModifyRequest(Optional.of(image), "오뜨", "멍청이");
 
         // when
         final MemberModifyResponse response = memberService.patchMemberInfo(member, request);
@@ -164,7 +162,7 @@ class MemberServiceTest {
         // data.sql
         final Member member = memberService.findById(1L);
         final MemberModifyRequest request
-            = new MemberModifyRequest(Optional.empty(),"오뜨","멍청이");
+                = new MemberModifyRequest(Optional.empty(), "오뜨", "멍청이");
 
         // when
         final MemberModifyResponse response = memberService.patchMemberInfo(member, request);
@@ -176,4 +174,28 @@ class MemberServiceTest {
             softly.assertThat(response.message()).isEqualTo(resultType.getMessage());
         });
     }
+
+    @Test
+    @DisplayName("회원 정보 수정 성공, 이미지 미포함을 나타내는 파일 이름")
+    void patchMemberInfoNoImageFileName() {
+        // given
+        // data.sql
+        final String emptyFileStartName = "34f2743d-a9463.png";
+        final Member member = memberService.findById(1L);
+        final MockMultipartFile image
+                = new MockMultipartFile("img", emptyFileStartName, "image/png", "img".getBytes());
+        final MemberModifyRequest request
+                = new MemberModifyRequest(Optional.of(image), "오뜨", "멍청이");
+
+        // when
+        final MemberModifyResponse response = memberService.patchMemberInfo(member, request);
+
+        // then
+        final MemberRequestResultType resultType = MemberRequestResultType.PATCH_MEMBER_INFO_SUCCESS;
+        assertSoftly(softly -> {
+            softly.assertThat(response.code()).isEqualTo(resultType.getCode());
+            softly.assertThat(response.message()).isEqualTo(resultType.getMessage());
+        });
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #51 

## 📝작업 내용

회원 정보 수정 시, 프로필 이미지가 빈 파일인지 확인하는 기능 구현
