### PR TITLE
[DEV] 차단 관련 유저의 데이터는 조회 안되도록 하는 로직 성능 개선

### DIFF
--- a/src/main/java/com/dnd/dotchi/domain/blacklist/repository/BlackListRepository.java
+++ b/src/main/java/com/dnd/dotchi/domain/blacklist/repository/BlackListRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.dotchi.domain.blacklist.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.dnd.dotchi.domain.blacklist.entity.BlackList;
@@ -7,4 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlackListRepository extends JpaRepository<BlackList, Long> {
 	Optional<BlackList> findByBlacklisterIdAndBlacklistedId(final Long blacklisterId, final Long blacklistedId);
+
+	List<BlackList> findByBlacklisterId(final Long blacklisterId);
+
+	List<BlackList> findByBlacklistedId(final Long blacklistedId);
 }

--- a/src/main/java/com/dnd/dotchi/domain/blacklist/service/BlacklistService.java
+++ b/src/main/java/com/dnd/dotchi/domain/blacklist/service/BlacklistService.java
@@ -42,10 +42,7 @@ public class BlacklistService {
         final Optional<BlackList> alreadyBlock
             = blackListRepository.findByBlacklisterIdAndBlacklistedId(blacklisterId, blacklistedId);
 
-        if(alreadyBlock.isPresent()) {
-            return true;
-        }
-        return false;
+        return alreadyBlock.isPresent();
     }
 
 }

--- a/src/main/java/com/dnd/dotchi/domain/card/entity/Card.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/entity/Card.java
@@ -28,8 +28,9 @@ import org.hibernate.annotations.ColumnDefault;
         name = "CARD",
         indexes = {
                 @Index(name = "idx_member_id_id", columnList = "member_id, id"),
-                @Index(name = "idx_theme_id_id", columnList = "theme_id, id"),
-                @Index(name = "idx_theme_id_comment_count", columnList = "theme_id, comment_count")
+                @Index(name = "idx_member_id_comment_count", columnList = "member_id, comment_count"),
+                @Index(name = "idx_theme_id_member_id_id", columnList = "theme_id, member_id, id"),
+                @Index(name = "idx_theme_id_member_id_comment_count", columnList = "theme_id, member_id, comment_count")
         }
 )
 public class Card extends BaseEntity {

--- a/src/main/java/com/dnd/dotchi/domain/card/repository/CardCustomRepository.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/repository/CardCustomRepository.java
@@ -11,14 +11,14 @@ public interface CardCustomRepository {
             final CardSortType cardSortType,
             final Long lastCardId,
             final Long lastCardCommentCount,
-            final Long memberId
+            final List<Long> idsRelatedToBlocking
     );
 
     List<Card> findCardsAllWithFilteringAndPaging(
             final CardSortType cardSortType,
             final Long lastCardId,
             final Long lastCardCommentCount,
-            final Long myId
+            final List<Long> idsRelatedToBlocking
     );
 
     List<Card> findCardsByMemberWithFilteringAndPaging(

--- a/src/main/java/com/dnd/dotchi/domain/card/repository/CommentCustomRepository.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/repository/CommentCustomRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import com.dnd.dotchi.domain.card.entity.Comment;
 
 public interface CommentCustomRepository {
-	List<Comment> findTop3LatestCommentsFilter(final Long memberId, final Long cardId);
+	List<Comment> findTop3LatestCommentsFilter(final List<Long> idsRelatedToBlocking, final Long cardId);
 }

--- a/src/test/java/com/dnd/dotchi/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/dnd/dotchi/domain/card/repository/CardRepositoryTest.java
@@ -34,7 +34,7 @@ class CardRepositoryTest {
 			CardSortType.HOT,
 			20L,
 			20L,
-			1L
+			List.of(2L)
 		);
 
 		// then
@@ -56,7 +56,7 @@ class CardRepositoryTest {
 			CardSortType.LATEST,
 			20L,
 			20L,
-			1L
+				List.of(2L)
 		);
 
 		// then
@@ -78,7 +78,7 @@ class CardRepositoryTest {
 			CardSortType.LATEST,
 			5L,
 			20L,
-			2L
+				List.of(1L)
 		);
 
 		// then
@@ -101,7 +101,7 @@ class CardRepositoryTest {
 			CardSortType.HOT,
 			15L,
 			15L,
-			1L
+				List.of(2L)
 		);
 
 		// then

--- a/src/test/java/com/dnd/dotchi/domain/card/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/dnd/dotchi/domain/card/repository/CommentRepositoryTest.java
@@ -1,9 +1,11 @@
 package com.dnd.dotchi.domain.card.repository;
 
-import static org.assertj.core.api.SoftAssertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.dnd.dotchi.domain.card.entity.Comment;
+import com.dnd.dotchi.global.config.JpaConfig;
+import com.dnd.dotchi.global.config.QuerydslConfig;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,16 +13,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import com.dnd.dotchi.domain.card.entity.Comment;
-import com.dnd.dotchi.domain.member.entity.Member;
-import com.dnd.dotchi.domain.member.service.MemberService;
-import com.dnd.dotchi.global.config.JpaConfig;
-import com.dnd.dotchi.global.config.QuerydslConfig;
-
 @Import({JpaConfig.class, QuerydslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
-public class CommentRepositoryTest {
+class CommentRepositoryTest {
 
 	@Autowired
 	CommentRepository commentRepository;
@@ -30,11 +26,10 @@ public class CommentRepositoryTest {
 	void getCommentsOnCardTest1() {
 		// given
 		// data-test.sql
-		final Long viewerId = 2L;
 		final Long cardId = 2L;
 
 		// when
-		final List<Comment> result = commentRepository.findTop3LatestCommentsFilter(viewerId, cardId);
+		final List<Comment> result = commentRepository.findTop3LatestCommentsFilter(List.of(1L), cardId);
 
 		// then
 		assertSoftly(softly -> {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #60 

## 📝작업 내용

차단 관련 유저의 데이터는 조회 안되도록 하는 로직 성능 개선
