### PR TITLE
테마별 카드 조회에서 각 카드마다 memberImageUrl 응답하도록 로직 추가

### DIFF
--- a/src/main/java/com/dnd/dotchi/domain/card/dto/response/CadsAllResultResponse.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/dto/response/CadsAllResultResponse.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "전체 카드 최신순/인기순 응답")
 public record CadsAllResultResponse(
 	@Schema(description = "전체 카드 최신순/인기순 응답")
-	List<CardsResponse> recentCards
+	List<CardsResponse> cards
 ) {
 	public static CadsAllResultResponse from(final List<Card> cards) {
 		return new CadsAllResultResponse(parseRecentCardsAllResponse(cards));

--- a/src/main/java/com/dnd/dotchi/domain/card/dto/response/CardsByThemeResultResponse.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/dto/response/CardsByThemeResultResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Schema(description = "테마별 카드 조회 결과 응답")
 public record CardsByThemeResultResponse(
         @Schema(description = "해당 테마의 최신순 카드 목록")
-        List<RecentCardsByThemeResponse> recentCards
+        List<RecentCardsByThemeResponse> cards
 ) {
         public static CardsByThemeResultResponse from(final List<Card> cardsByTheme) {
                 return new CardsByThemeResultResponse(parseRecentCardsByThemeResponse(cardsByTheme));

--- a/src/main/java/com/dnd/dotchi/domain/card/dto/response/RecentCardsByThemeResponse.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/dto/response/RecentCardsByThemeResponse.java
@@ -14,6 +14,9 @@ public record RecentCardsByThemeResponse(
         @Schema(description = "해당 카드를 작성한 회원 닉네임")
         String memberName,
 
+        @Schema(description = "해당 카드를 작성한 회원 프로필 이미지 URL")
+        String memberImageUrl,
+
         @Schema(description = "카드 이미지 URL")
         String cardImageUrl,
 
@@ -32,6 +35,7 @@ public record RecentCardsByThemeResponse(
                 card.getId(),
                 card.getMember().getId(),
                 card.getMember().getNickname(),
+                card.getMember().getImageUrl(),
                 card.getImageUrl(),
                 card.getTheme().getId(),
                 card.getBackName(),

--- a/src/test/java/com/dnd/dotchi/domain/card/service/CardServiceTest.java
+++ b/src/test/java/com/dnd/dotchi/domain/card/service/CardServiceTest.java
@@ -101,7 +101,7 @@ class CardServiceTest {
         final CardsByThemeResponse result = cardService.getCardsByTheme(member, request);
 
         // then
-        final List<RecentCardsByThemeResponse> responses = result.result().recentCards();
+        final List<RecentCardsByThemeResponse> responses = result.result().cards();
         assertSoftly(softly -> {
             softly.assertThat(responses).hasSize(1);
             softly.assertThat(responses.get(0).cardId()).isEqualTo(22);
@@ -125,7 +125,7 @@ class CardServiceTest {
         final CardsByThemeResponse result = cardService.getCardsByTheme(member, request);
 
         // then
-        final List<RecentCardsByThemeResponse> responses = result.result().recentCards();
+        final List<RecentCardsByThemeResponse> responses = result.result().cards();
         assertSoftly(softly -> {
             softly.assertThat(responses).hasSize(2);
             softly.assertThat(responses.get(0).cardId()).isEqualTo(10);
@@ -150,7 +150,7 @@ class CardServiceTest {
         final CardsAllResponse result = cardService.getCardAll(member, request);
 
         // then
-        final List<CardsResponse> responses = result.result().recentCards();
+        final List<CardsResponse> responses = result.result().cards();
         final CardsRequestResultType resultType = CardsRequestResultType.GET_CARDS_ALL_SUCCESS;
         assertSoftly(softly -> {
             softly.assertThat(result.code()).isEqualTo(resultType.getCode());
@@ -184,7 +184,7 @@ class CardServiceTest {
         final CardsAllResponse result = cardService.getCardAll(member, request);
 
         // then
-        final List<CardsResponse> responses = result.result().recentCards();
+        final List<CardsResponse> responses = result.result().cards();
         final CardsRequestResultType resultType = CardsRequestResultType.GET_CARDS_ALL_SUCCESS;
         assertSoftly(softly -> {
             softly.assertThat(result.code()).isEqualTo(resultType.getCode());


### PR DESCRIPTION
## #️⃣연관된 이슈

close #65

## 📝작업 내용

테마별 카드 조회에서 각 카드마다 memberImageUrl 응답하도록 로직 추가