### PR TITLE
[BUG] 인기순 조회시, 마지막 카드의 댓글 수와 댓글 수가 같은 카드가 존재할 시 안넘어오는 버그 픽스

### DIFF
--- a/src/main/java/com/dnd/dotchi/domain/card/repository/CardCustomRepositoryImpl.java
+++ b/src/main/java/com/dnd/dotchi/domain/card/repository/CardCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.dnd.dotchi.domain.card.entity.TodayCard;
 import com.dnd.dotchi.domain.card.entity.vo.CardSortType;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class CardCustomRepositoryImpl implements CardCustomRepository {
 
     private static final int BASIC_PAGE_SIZE = 10;
     private static final int LIMIT_CARDS = 5;
+    private static final int DEFAULT_FIRST_LAST_CARD_ID = 99999;
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -71,7 +73,14 @@ public class CardCustomRepositoryImpl implements CardCustomRepository {
     ) {
         return switch (cardSortType) {
             case LATEST -> card.id.lt(lastCardId);
-            case HOT -> card.commentCount.lt(lastCardCommentCount);
+            case HOT -> {
+                if (lastCardId == DEFAULT_FIRST_LAST_CARD_ID) {
+                    yield card.commentCount.loe(lastCardCommentCount);
+                }
+                yield card.commentCount.eq(lastCardCommentCount)
+                        .and(card.id.gt(lastCardId))
+                        .or(card.commentCount.lt(lastCardCommentCount));
+            }
         };
     }
 

--- a/src/test/java/com/dnd/dotchi/domain/card/repository/CardRepositoryTest.java
+++ b/src/test/java/com/dnd/dotchi/domain/card/repository/CardRepositoryTest.java
@@ -106,15 +106,16 @@ class CardRepositoryTest {
 
 		// then
 		assertSoftly(softly -> {
-			softly.assertThat(result).hasSize(8);
-			softly.assertThat(result.get(0).getId()).isEqualTo(19);
-			softly.assertThat(result.get(1).getId()).isEqualTo(20);
-			softly.assertThat(result.get(2).getId()).isEqualTo(21);
-			softly.assertThat(result.get(3).getId()).isEqualTo(22);
-			softly.assertThat(result.get(4).getId()).isEqualTo(23);
-			softly.assertThat(result.get(5).getId()).isEqualTo(25);
-			softly.assertThat(result.get(6).getId()).isEqualTo(27);
-			softly.assertThat(result.get(7).getId()).isEqualTo(29);
+			softly.assertThat(result).hasSize(9);
+			softly.assertThat(result.get(0).getId()).isEqualTo(17);
+			softly.assertThat(result.get(1).getId()).isEqualTo(19);
+			softly.assertThat(result.get(2).getId()).isEqualTo(20);
+			softly.assertThat(result.get(3).getId()).isEqualTo(21);
+			softly.assertThat(result.get(4).getId()).isEqualTo(22);
+			softly.assertThat(result.get(5).getId()).isEqualTo(23);
+			softly.assertThat(result.get(6).getId()).isEqualTo(25);
+			softly.assertThat(result.get(7).getId()).isEqualTo(27);
+			softly.assertThat(result.get(8).getId()).isEqualTo(29);
 		});
 	}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #69 

## 📝작업 내용

인기순 조회시, 마지막 카드의 댓글 수와 댓글 수가 같은 카드가 존재할 시 안넘어오는 버그 픽스